### PR TITLE
autodocs: wait seconds before updating echo area

### DIFF
--- a/modes/lisp.lisp
+++ b/modes/lisp.lisp
@@ -971,8 +971,21 @@ sb-introspect:definition-source)'."
              (pushnew 'echo-area-autodoc (styles echo-area))
              (message nodes)))))))
 
+(defvar *autodoc-wait-seconds* 0.5
+  "Seconds to wait before updating autodocs echo area.")
+
+(defvar *autodoc-turn* (gensym))
+
 (defmethod on-post-command progn ((buffer autodoc-mode))
-  (maybe-show-autodoc))
+  (if (or (not *autodoc-wait-seconds*) (zerop *autodoc-wait-seconds*))
+      (maybe-show-autodoc)
+      (let ((my-turn (gensym)))
+        (setf *autodoc-turn* my-turn)
+        (sb-ext:schedule-timer
+         (sb-ext:make-timer (lambda ()
+                              (when (eq my-turn *autodoc-turn*)
+                                (maybe-show-autodoc))))
+         *autodoc-wait-seconds*))))
 
 ;;; Parser
 


### PR DESCRIPTION
I'm using this. Wait some time before autodocs updates the echo area. This prevents the echo area to get updated multiple times when navigating with cursor. It is tunable.
Uses SBCL timers, I hope they are not costly.