### PR TITLE
Fix startup problem for macOS

### DIFF
--- a/start.lisp
+++ b/start.lisp
@@ -31,7 +31,8 @@ the following effect:
     (ceramic:setup)
     (with-open-file
         (s (merge-pathnames
-            #p"resources/default_app/package.json"
+            #+darwin #p"Electron.app/Contents/Resources/default_app/package.json"
+            #-darwin #p"resources/default_app/package.json"
             (ceramic.file:release-directory))
            :direction :output
            :if-exists :supersede)


### PR DESCRIPTION
On macOS the Electron is packed into macOS Application Bundle (.app) file and shipped, thus the `package.json` is located at `~/.ceramic/Electron.app/Contents/Resources/default_app/package.json`. The Neomacs successfully started after the modification on SBCL 2.5.0, macOS Sequoia 15.2, Apple silicon M3.